### PR TITLE
fix: deep merge TOML context files instead of shallow update

### DIFF
--- a/jinja_tree/infra/adapters/context.py
+++ b/jinja_tree/infra/adapters/context.py
@@ -111,6 +111,22 @@ class TOMLContextConfig(DataClassJsonMixin):
         self.paths = [os.path.abspath(x) for x in self.paths]
 
 
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge override into base, returning a new dict.
+
+    When both base and override have a dict value for the same key,
+    the dicts are merged recursively instead of the override replacing
+    the entire base value.
+    """
+    result = dict(base)
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
 class TOMLContextAdapter(ContextPort):
     def __init__(self, config: Config, plugin_config: Dict[str, Any]):
         self.config = config
@@ -135,5 +151,5 @@ class TOMLContextAdapter(ContextPort):
         res: Dict[str, Any] = {}
         for path in self.plugin_config.paths:
             if path:
-                res.update(self._get_context_single_path(path))
+                res = _deep_merge(res, self._get_context_single_path(path))
         return res

--- a/tests/infra/data/deep1.toml
+++ b/tests/infra/data/deep1.toml
@@ -1,0 +1,9 @@
+key1 = "value1"
+
+[database]
+host = "localhost"
+port = 5432
+
+[database.options]
+timeout = 30
+retries = 3

--- a/tests/infra/data/deep2.toml
+++ b/tests/infra/data/deep2.toml
@@ -1,0 +1,9 @@
+key2 = "value2"
+
+[database]
+port = 3306
+name = "mydb"
+
+[database.options]
+retries = 5
+verbose = true

--- a/tests/infra/test_adapters_context.py
+++ b/tests/infra/test_adapters_context.py
@@ -7,6 +7,7 @@ from jinja_tree.infra.adapters.context import (
     ConfigurationContextAdapter,
     EnvContextAdapter,
     TOMLContextAdapter,
+    _deep_merge,
 )
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -57,3 +58,40 @@ def test_toml_file_backward_compat_path():
         config, {"path": os.path.join(SCRIPT_DIR, "data", "foo.toml")}
     )
     assert x.get_context() == {"key1": "value1", "key2": "value2"}
+
+
+def test_deep_merge_nested_dicts():
+    base = {"a": 1, "nested": {"x": 10, "y": 20}}
+    override = {"b": 2, "nested": {"y": 99, "z": 30}}
+    result = _deep_merge(base, override)
+    assert result == {"a": 1, "b": 2, "nested": {"x": 10, "y": 99, "z": 30}}
+    # originals are not mutated
+    assert base == {"a": 1, "nested": {"x": 10, "y": 20}}
+
+
+def test_toml_deep_merge_multiple_files():
+    """Merging multiple TOML files should deep-merge nested tables."""
+    config = Config()
+    x = TOMLContextAdapter(
+        config,
+        {
+            "paths": [
+                os.path.join(SCRIPT_DIR, "data", "deep1.toml"),
+                os.path.join(SCRIPT_DIR, "data", "deep2.toml"),
+            ]
+        },
+    )
+    assert x.get_context() == {
+        "key1": "value1",
+        "key2": "value2",
+        "database": {
+            "host": "localhost",
+            "port": 3306,
+            "name": "mydb",
+            "options": {
+                "timeout": 30,
+                "retries": 5,
+                "verbose": True,
+            },
+        },
+    }


### PR DESCRIPTION
## Summary

- When multiple TOML files are loaded via the `TOMLContextAdapter`, nested tables (dicts) are now **recursively merged** — individual keys within each table are preserved from all files, rather than later files replacing entire tables.
- Adds a `_deep_merge` helper function and corresponding tests with dedicated TOML fixtures.

## Changes

- `jinja_tree/infra/adapters/context.py` — added `_deep_merge()` recursive dict merge; replaced `dict.update()` with `_deep_merge()` in `TOMLContextAdapter.get_context()`
- `tests/infra/data/deep1.toml` / `deep2.toml` — new TOML fixtures with overlapping nested tables
- `tests/infra/test_adapters_context.py` — added `test_deep_merge_nested_dicts` (unit) and `test_toml_deep_merge_multiple_files` (integration)


Made with [Cursor](https://cursor.com)