### PR TITLE
Remove Task references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@ FROM alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:c4f5de312ee66d46810635ffc5df34a1973ba753e7241ce3a08ef979ddd7bea5 /uv /uvx /bin/
 
-ENV TASK=make
 ENV UV_NO_CACHE=1
 ENV UV_PYTHON_INSTALL_DIR=/python
 
 RUN apk update && apk upgrade && apk add bash make && rm -rf /var/cache/apk/*
 RUN mkdir -p /app
 COPY Makefile README.md pyproject.toml uv.lock /app/
-RUN cd /app && export UV_SYNC_OPTS="--frozen --no-dev --no-install-project" && $TASK install
+RUN cd /app && export UV_SYNC_OPTS="--frozen --no-dev --no-install-project" && make install
 COPY jinja_tree /app/jinja_tree/
 COPY entrypoint.sh entrypoint-stdin.sh /app/
-RUN cd /app && export UV_SYNC_OPTS="--frozen --no-dev" && $TASK install
+RUN cd /app && export UV_SYNC_OPTS="--frozen --no-dev" && make install
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 ![Python Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/python312plus.svg)
 [![UV Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/uv.svg)](https://docs.astral.sh/uv/)
-[![Task Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/task.svg)](https://taskfile.dev/)
 [![Mergify Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/mergify.svg)](https://mergify.com/)
 [![Renovate Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/renovate.svg)](https://docs.renovatebot.com/)
 [![MIT Licensed](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/mit.svg)](https://en.wikipedia.org/wiki/MIT_License)

--- a/README.md.template
+++ b/README.md.template
@@ -4,7 +4,6 @@
 
 ![Python Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/python312plus.svg)
 [![UV Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/uv.svg)](https://docs.astral.sh/uv/)
-[![Task Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/task.svg)](https://taskfile.dev/)
 [![Mergify Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/mergify.svg)](https://mergify.com/)
 [![Renovate Badge](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/renovate.svg)](https://docs.renovatebot.com/)
 [![MIT Licensed](https://raw.githubusercontent.com/fabien-marty/common/refs/heads/main/badges/mit.svg)](https://en.wikipedia.org/wiki/MIT_License)

--- a/entrypoint-stdin.sh
+++ b/entrypoint-stdin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export UV="/app/.tmp/taskfile-python-uv/uv/uv"
+export UV="uv"
 
 if ! test -d /code; then
   if test -d /workdir; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export UV="/app/.tmp/taskfile-python-uv/uv/uv"
+export UV="uv"
 
 if ! test -d /code; then
   # DEPRECATED: only for smooth transition


### PR DESCRIPTION
## Why

The project has migrated from Taskfile-based automation to Makefile-based commands, so the remaining Task references should be removed to avoid confusion and stale documentation.

## Changes

- Replaced the Docker build's `TASK` indirection with direct `make install` invocations.
- Removed the Task badge from `README.md` and `README.md.template`.
- Updated the container entrypoints to call the installed `uv` binary directly instead of the old taskfile-specific path.