### PR TITLE
Remove Docker support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,44 +85,11 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
-  publish_docker:
-    runs-on: ubuntu-latest
-    needs: ["lint_and_test"]
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 
-      - name: Log in to the Container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor:
-            latest=true
-          tags: |
-            type=ref,event=tag
-      - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
   mergify-ci-status: # this is a special job for mergify
     runs-on: ubuntu-24.04
-    needs: ["lint_and_test", "publish_docker"]
+    needs: ["lint_and_test"]
     steps:
       - name: Status
         run: |
           echo "OK"
+

--- a/README.md
+++ b/README.md
@@ -152,10 +152,6 @@ See [this directory](jinja_tree/app/embedded_extensions/) for others
 > If you want to get a better readability of `jinja-tree` output (colors...), you can also use `pip install rich` to install 
 > this **optional** dependency.
 
-> [!NOTE]
-> A docker image is also available. You can use it to avoid any specific installation.
-> See at the end of the "Usage" section for more details.
-
 ## Usage
 
 ### Main CLI
@@ -275,41 +271,5 @@ Hello bar
 
 
 ``` 
-
-</details>
-
-### Docker image
-
-A docker image is also available. You can use it this way:
-
-```bash
-docker run --rm -t -v $(pwd):/code --user=$(id -u) ghcr.io/fabien-marty/jinja-tree:latest /code
-```
-
-*(we mount the current directory in the `/code` directory in the container and execute `jinja-tree` in this `/code` directory)*
-
-> [!WARNING]
-> If you plan to use environment variables with the docker image, you will have to use (possibly multiple times) the `-e VAR=VALUE` option to pass them to the container. 
-> With docker, it's more practical to use a `.env` (dotenv) file as it will be automatically mounted in the container.
-
-If you want to add some CLI options, you can add them like in this example:
-
-```bash
-docker run --rm -t -v $(pwd):/code --user=$(id -u) ghcr.io/fabien-marty/jinja-tree:latest --verbose /code
-```
-
-*(we added `--verbose` just before the `/code` argument)*
-
-<details>
-
-<summary>If you want to use the `jinja-stdin` CLI with docker?</summary>
-
-
-```bash
-echo "FOO {{ BAR }}" |docker run --rm -i -e BAR=BAZ --user=$(id -u) --entrypoint /app/entrypoint-stdin.sh ghcr.io/fabien-marty/jinja-tree:latest
-```
-
-
-*(it will output `FOO BAZ`)*
 
 </details>

--- a/README.md.template
+++ b/README.md.template
@@ -151,10 +151,6 @@ See [this directory]({{BASEURL}}jinja_tree/app/embedded_extensions/) for others
 > If you want to get a better readability of `jinja-tree` output (colors...), you can also use `pip install rich` to install 
 > this **optional** dependency.
 
-> [!NOTE]
-> A docker image is also available. You can use it to avoid any specific installation.
-> See at the end of the "Usage" section for more details.
-
 ## Usage
 
 ### Main CLI
@@ -202,38 +198,3 @@ Hello bar
 
 </details>
 
-### Docker image
-
-A docker image is also available. You can use it this way:
-
-```bash
-docker run --rm -t -v $(pwd):/code --user=$(id -u) ghcr.io/fabien-marty/jinja-tree:latest /code
-```
-
-*(we mount the current directory in the `/code` directory in the container and execute `jinja-tree` in this `/code` directory)*
-
-> [!WARNING]
-> If you plan to use environment variables with the docker image, you will have to use (possibly multiple times) the `-e VAR=VALUE` option to pass them to the container. 
-> With docker, it's more practical to use a `.env` (dotenv) file as it will be automatically mounted in the container.
-
-If you want to add some CLI options, you can add them like in this example:
-
-```bash
-docker run --rm -t -v $(pwd):/code --user=$(id -u) ghcr.io/fabien-marty/jinja-tree:latest --verbose /code
-```
-
-*(we added `--verbose` just before the `/code` argument)*
-
-<details>
-
-<summary>If you want to use the `jinja-stdin` CLI with docker?</summary>
-
-{% raw %}
-```bash
-echo "FOO {{ BAR }}" |docker run --rm -i -e BAR=BAZ --user=$(id -u) --entrypoint /app/entrypoint-stdin.sh ghcr.io/fabien-marty/jinja-tree:latest
-```
-{% endraw %}
-
-*(it will output `FOO BAZ`)*
-
-</details>


### PR DESCRIPTION
## Why

Remove the Docker-based distribution path so the project only documents and publishes the native Python workflow.

## Changes

- Delete the Docker usage section from `README.md.template`.
- Remove the `publish_docker` job from `.github/workflows/ci.yml`.
- Update the remaining CI job dependency so Mergify no longer waits on Docker publishing.