### PR TITLE
Implement counter extension for Jinja2 templates

### DIFF
--- a/docs/details-about-configuration.md
+++ b/docs/details-about-configuration.md
@@ -157,6 +157,7 @@ strict_undefined = true
 
 # Disable embedded jinja extensions (if true)
 # List of embedded jinja extensions (for information only):
+# - jinja_tree.app.embedded_extensions.counter.CounterExtension
 # - jinja_tree.app.embedded_extensions.from_json.FromJsonExtension
 # - jinja_tree.app.embedded_extensions.from_toml.FromTomlExtension
 # - jinja_tree.app.embedded_extensions.shell.ShellExtension

--- a/docs/jinja-tree.toml
+++ b/docs/jinja-tree.toml
@@ -25,6 +25,7 @@ strict_undefined = true
 
 # Disable embedded jinja extensions (if true)
 # List of embedded jinja extensions (for information only):
+# - jinja_tree.app.embedded_extensions.counter.CounterExtension
 # - jinja_tree.app.embedded_extensions.from_json.FromJsonExtension
 # - jinja_tree.app.embedded_extensions.from_toml.FromTomlExtension
 # - jinja_tree.app.embedded_extensions.shell.ShellExtension

--- a/jinja_tree/app/config.py
+++ b/jinja_tree/app/config.py
@@ -5,6 +5,7 @@ from typing import Any
 from dataclasses_json import DataClassJsonMixin, Undefined
 
 EMBEDDED_EXTENSIONS = [
+    "jinja_tree.app.embedded_extensions.counter.CounterExtension",
     "jinja_tree.app.embedded_extensions.from_json.FromJsonExtension",
     "jinja_tree.app.embedded_extensions.from_toml.FromTomlExtension",
     "jinja_tree.app.embedded_extensions.shell.ShellExtension",

--- a/jinja_tree/app/embedded_extensions/counter.py
+++ b/jinja_tree/app/embedded_extensions/counter.py
@@ -1,0 +1,33 @@
+from jinja2.ext import Extension
+
+
+def counter(environment, start=None, name="default"):
+    counters = getattr(environment, "_counter_values", None)
+    if counters is None:
+        counters = {}
+        environment._counter_values = counters
+
+    if name not in counters:
+        counters[name] = 0 if start is None else start
+
+    current_value = counters[name]
+    counters[name] += 1
+    return current_value
+
+
+class CounterExtension(Extension):
+    """Jinja2 extension to expose incrementing named counters.
+
+    Examples:
+    {{ counter() }} {{ counter() }}
+    => 0 1
+
+    {{ counter(name='foo', start=3) }} {{ counter(name='foo') }}
+    => 3 4
+    """
+
+    def __init__(self, environment):
+        super().__init__(environment)
+        environment.globals["counter"] = lambda start=None, name="default": counter(
+            environment, start=start, name=name
+        )

--- a/jinja_tree/app/jinja.py
+++ b/jinja_tree/app/jinja.py
@@ -58,7 +58,7 @@ class JinjaService:
             extensions=self.config.resolved_extensions,
         )
         template = env.get_template(self.template_name)
-        template.globals = self.context_service.get_context(absolute_path)
+        template.globals.update(self.context_service.get_context(absolute_path))
         try:
             output = template.render()
         except UndefinedError:

--- a/tests/app/test_embedded.py
+++ b/tests/app/test_embedded.py
@@ -101,9 +101,7 @@ def test_counter_custom_start_first_call():
     env = Environment(
         extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
     )
-    template = env.from_string(
-        "{{ counter(start=3) }} {{ counter() }} {{ counter() }}"
-    )
+    template = env.from_string("{{ counter(start=3) }} {{ counter() }} {{ counter() }}")
     result = template.render()
     assert result == "3 4 5"
 

--- a/tests/app/test_embedded.py
+++ b/tests/app/test_embedded.py
@@ -2,6 +2,22 @@ import json
 
 from jinja2 import Environment
 
+from jinja_tree.app.config import Config
+from jinja_tree.app.context import ContextPort, ContextService
+from jinja_tree.app.jinja import JinjaService
+
+
+class MockContextAdapter(ContextPort):
+    def __init__(self, config: Config, plugin_config: dict[str, object]):
+        pass
+
+    def get_context(self, absolute_path: str | None = None) -> dict[str, object]:
+        return {}
+
+    @classmethod
+    def get_config_name(cls) -> str:
+        return "mock"
+
 
 def test_shell():
     env = Environment(
@@ -70,3 +86,60 @@ def test_urlencode():
     template = env.from_string('test {{ "https://google.com"|urlencode(safe="") }}')
     result = template.render()
     assert result == "test https%3A%2F%2Fgoogle.com"
+
+
+def test_counter_default_start():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string("{{ counter() }} {{ counter() }} {{ counter() }}")
+    result = template.render()
+    assert result == "0 1 2"
+
+
+def test_counter_custom_start_first_call():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string(
+        "{{ counter(start=3) }} {{ counter() }} {{ counter() }}"
+    )
+    result = template.render()
+    assert result == "3 4 5"
+
+
+def test_counter_named_counters_are_independent():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string(
+        "{{ counter() }} {{ counter(name='foo') }} {{ counter() }} "
+        "{{ counter(name='foo') }} {{ counter(name='bar') }} {{ counter(name='bar') }}"
+    )
+    result = template.render()
+    assert result == "0 0 1 1 0 1"
+
+
+def test_counter_named_start_applies_per_name():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string(
+        "{{ counter(name='foo', start=3) }} {{ counter(name='foo') }} "
+        "{{ counter() }} {{ counter(name='bar', start=7) }} {{ counter(name='bar') }}"
+    )
+    result = template.render()
+    assert result == "3 4 0 7 8"
+
+
+def test_counter_resets_between_renders():
+    config = Config()
+    context_adapter = MockContextAdapter(config, {})
+    context_service = ContextService(config, [context_adapter])
+    jinja_service = JinjaService(config, context_service)
+
+    first_result = jinja_service.render_string("{{ counter() }} {{ counter() }}")
+    second_result = jinja_service.render_string("{{ counter() }} {{ counter() }}")
+
+    assert first_result == "0 1"
+    assert second_result == "0 1"


### PR DESCRIPTION
## Why

The system needed a way to maintain and increment counters within Jinja2 templates, allowing users to generate sequential numbers or labels during template rendering without manual tracking in the context.

## Changes

- Added `CounterExtension` in `jinja_tree/app/embedded_extensions/counter.py` which provides a `counter()` global function in Jinja2.
- The `counter()` function supports optional `start` value and named counters (defaulting to 'default') for independent tracking.
- Registered `CounterExtension` in `jinja_tree/app/config.py` to make it available by default.
- Updated `JinjaService` in `jinja_tree/app/jinja.py` to use `update()` on template globals instead of assignment, ensuring extensions that add globals (like the new counter extension) are preserved.
- Added comprehensive unit tests in `tests/app/test_embedded.py` covering default behavior, custom start values, named counters, and state isolation between renders.

## Risks & Side Effects

No significant risks or side effects. The counter state is stored on the Jinja environment object during a render session and is isolated between separate rendering calls.

## Links
