### PR TITLE
Update counter extension: start at 1 and add named value retrieval

### DIFF
--- a/jinja_tree/app/embedded_extensions/counter.py
+++ b/jinja_tree/app/embedded_extensions/counter.py
@@ -1,18 +1,41 @@
 from jinja2.ext import Extension
 
 
-def counter(environment, start=None, name="default"):
+def get_named_values(environment):
+    named_values = getattr(environment, "_counter_named_values", None)
+    if named_values is None:
+        named_values = {}
+        environment._counter_named_values = named_values
+    return named_values
+
+
+def counter(environment, start=None, name="default", set_value_name=None):
     counters = getattr(environment, "_counter_values", None)
     if counters is None:
         counters = {}
         environment._counter_values = counters
 
+    named_values = get_named_values(environment)
+    if set_value_name is not None and set_value_name in named_values:
+        raise ValueError(f"counter value name '{set_value_name}' is already defined")
+
     if name not in counters:
-        counters[name] = 0 if start is None else start
+        counters[name] = 1 if start is None else start
 
     current_value = counters[name]
     counters[name] += 1
+
+    if set_value_name is not None:
+        named_values[set_value_name] = current_value
+
     return current_value
+
+
+def counter_value(environment, name):
+    named_values = get_named_values(environment)
+    if name not in named_values:
+        raise ValueError(f"counter value name '{name}' is not defined")
+    return named_values[name]
 
 
 class CounterExtension(Extension):
@@ -20,14 +43,25 @@ class CounterExtension(Extension):
 
     Examples:
     {{ counter() }} {{ counter() }}
-    => 0 1
+    => 1 2
 
     {{ counter(name='foo', start=3) }} {{ counter(name='foo') }}
     => 3 4
+
+    {{ counter(name='steps', set_value_name='login') }} {{ counter_value('login') }}
+    => 1 1
     """
 
     def __init__(self, environment):
         super().__init__(environment)
-        environment.globals["counter"] = lambda start=None, name="default": counter(
-            environment, start=start, name=name
+        environment.globals["counter"] = (
+            lambda start=None, name="default", set_value_name=None: counter(
+                environment,
+                start=start,
+                name=name,
+                set_value_name=set_value_name,
+            )
+        )
+        environment.globals["counter_value"] = lambda name: counter_value(
+            environment, name
         )

--- a/tests/app/test_embedded.py
+++ b/tests/app/test_embedded.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from jinja2 import Environment
 
 from jinja_tree.app.config import Config
@@ -94,7 +95,7 @@ def test_counter_default_start():
     )
     template = env.from_string("{{ counter() }} {{ counter() }} {{ counter() }}")
     result = template.render()
-    assert result == "0 1 2"
+    assert result == "1 2 3"
 
 
 def test_counter_custom_start_first_call():
@@ -115,7 +116,7 @@ def test_counter_named_counters_are_independent():
         "{{ counter(name='foo') }} {{ counter(name='bar') }} {{ counter(name='bar') }}"
     )
     result = template.render()
-    assert result == "0 0 1 1 0 1"
+    assert result == "1 1 2 2 1 2"
 
 
 def test_counter_named_start_applies_per_name():
@@ -127,7 +128,7 @@ def test_counter_named_start_applies_per_name():
         "{{ counter() }} {{ counter(name='bar', start=7) }} {{ counter(name='bar') }}"
     )
     result = template.render()
-    assert result == "3 4 0 7 8"
+    assert result == "3 4 1 7 8"
 
 
 def test_counter_resets_between_renders():
@@ -139,5 +140,75 @@ def test_counter_resets_between_renders():
     first_result = jinja_service.render_string("{{ counter() }} {{ counter() }}")
     second_result = jinja_service.render_string("{{ counter() }} {{ counter() }}")
 
-    assert first_result == "0 1"
-    assert second_result == "0 1"
+    assert first_result == "1 2"
+    assert second_result == "1 2"
+
+
+def test_counter_can_store_named_value():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string(
+        "{{ counter(name='steps', set_value_name='login') }} "
+        "{{ counter(name='steps') }} {{ counter_value('login') }}"
+    )
+
+    result = template.render()
+
+    assert result == "1 2 1"
+
+
+def test_counter_named_values_are_independent_from_counter_name():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string(
+        "{{ counter(name='foo', set_value_name='first_foo') }} "
+        "{{ counter(name='bar', start=3, set_value_name='first_bar') }} "
+        "{{ counter_value('first_bar') }} {{ counter_value('first_foo') }}"
+    )
+
+    result = template.render()
+
+    assert result == "1 3 3 1"
+
+
+def test_counter_named_values_reset_between_renders():
+    config = Config()
+    context_adapter = MockContextAdapter(config, {})
+    context_service = ContextService(config, [context_adapter])
+    jinja_service = JinjaService(config, context_service)
+
+    first_result = jinja_service.render_string(
+        "{{ counter(set_value_name='step') }} {{ counter_value('step') }}"
+    )
+    second_result = jinja_service.render_string(
+        "{{ counter(set_value_name='step') }} {{ counter_value('step') }}"
+    )
+
+    assert first_result == "1 1"
+    assert second_result == "1 1"
+
+
+def test_counter_value_raises_for_unknown_name():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string("{{ counter_value('missing') }}")
+
+    with pytest.raises(ValueError, match="counter value name 'missing' is not defined"):
+        template.render()
+
+
+def test_counter_raises_when_named_value_is_redefined():
+    env = Environment(
+        extensions=["jinja_tree.app.embedded_extensions.counter.CounterExtension"]
+    )
+    template = env.from_string(
+        "{{ counter(set_value_name='step') }} {{ counter(set_value_name='step') }}"
+    )
+
+    with pytest.raises(
+        ValueError, match="counter value name 'step' is already defined"
+    ):
+        template.render()


### PR DESCRIPTION
## Why

The counter extension previously started at 0, which is often less intuitive for template users than starting at 1. Additionally, there was no way to capture a specific counter value to reference it later in the template. These changes make the counter more user-friendly and powerful for complex document generation.

## Changes

- Modified the default `start` value of the `counter` function from 0 to 1.
- Updated internal logic to support a `set_value_name` argument in the `counter` global function.
- Introduced a new `counter_value(name)` global function to retrieve previously stored values.
- Ensured that named values are stored in the Jinja environment and reset between renders.
- Added validation to prevent re-defining a named value within the same render.
- Updated and expanded tests to cover the new behavior and ensure proper isolation.

## Risks & Side Effects

- **Breaking Change**: Templates that rely on `counter()` starting at 0 will now start at 1. They will need to be updated to use `counter(start=0)` if the previous behavior is required.
- **Errors**: Using `counter_value()` with an unknown name or reusing a name in `counter(set_value_name=...)` will now raise a `ValueError`.

## Links
